### PR TITLE
add support to build kafka 0.8.2-beta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 KAFKA_VERSION ?= 0.8.1.1
 SCALA_VERSION ?= 2.9.2
-VERSION = $(KAFKA_VERSION)
+VERSION = $(shell echo $(KAFKA_VERSION) | sed "s/-/_/")
 BUILD_NUMBER ?= 1
 TARBALL_NAME = kafka_$(SCALA_VERSION)-$(KAFKA_VERSION)
 TARBALL = $(TARBALL_NAME).tgz
@@ -12,6 +12,7 @@ PWD = $(shell pwd)
 rpm: $(TARBALL)
 	@rpmbuild -v -bb \
 			--define "version $(VERSION)" \
+			--define "kafka_version $(KAFKA_VERSION)" \
 			--define "build_number $(BUILD_NUMBER)" \
 			--define "tarball $(TARBALL)" \
 			--define "tarball_name $(TARBALL_NAME)" \
@@ -27,6 +28,7 @@ clean:
 $(TARBALL):
 	@spectool \
 			--define "version $(VERSION)" \
+			--define "kafka_version $(KAFKA_VERSION)" \
 			--define "tarball $(TARBALL)" \
 			-g kafka.spec
 

--- a/kafka.spec
+++ b/kafka.spec
@@ -8,10 +8,10 @@ Version: %{version}
 Release: %{build_number}
 License: Apache License, Version 2.0
 Group: Applications
-Source0: http://apache.mirrors.spacedump.net/kafka/%{version}/%{tarball}
+Source0: http://apache.mirrors.spacedump.net/kafka/%{kafka_version}/%{tarball}
 Source1: kafka.init
 URL: http://kafka.apache.org/
-BuildRoot: %{_tmppath}/%{name}-%{version}-root
+BuildRoot: %{_tmppath}/%{name}-%{kafka_version}-root
 Prefix: /opt
 Vendor: Apache Software Foundation
 Packager: Ivan Dyachkov <ivan.dyachkov@klarna.com>
@@ -24,7 +24,7 @@ Kafka is designed to allow a single cluster to serve as the central data backbon
 %setup -n %{tarball_name}
 
 %build
-rm libs/{kafka_*-javadoc.jar,kafka_*-scaladoc.jar,kafka_*-sources.jar,*.asc}
+rm -f libs/{kafka_*-javadoc.jar,kafka_*-scaladoc.jar,kafka_*-sources.jar,*.asc}
 rm config/zookeeper.properties
 
 %install


### PR DESCRIPTION
RPM spec prohibit to specify version with dash symbol while `kafka 0.8.2-beta` have one.

My patch divide kafka version and package version.

tested with command
`KAFKA_VERSION=0.8.2-beta make`

rm -f required to ignore not existing files. kafka 0.8.2-beta distribution do not contain asc for jar files.
