### PR TITLE
Add %{dist} (i.e. "el6") to Release

### DIFF
--- a/kafka.spec
+++ b/kafka.spec
@@ -5,7 +5,7 @@
 Summary: Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.
 Name: kafka
 Version: %{version}
-Release: %{build_number}
+Release: %{build_number}%{?dist}
 License: Apache License, Version 2.0
 Group: Applications
 Source0: http://apache.mirrors.spacedump.net/kafka/%{kafka_version}/%{tarball}


### PR DESCRIPTION
This makes a RPM be end up like this `kafka-0.10.1.0-1.el6.x86_64.rpm`, instead of `kafka-0.10.1.0-1.x86_64.rpm`. Good for differentiating between different target systems (RHEL 7 vs 6 for example).
