### PR TITLE
Update kafka.init

### DIFF
--- a/kafka.init
+++ b/kafka.init
@@ -117,7 +117,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $PROG: "
-    killproc -p $PIDFILE -d 60 $PROG
+    killproc -p $PIDFILE -d 600 $PROG
     RETVAL=$?
     [ $RETVAL -eq 0 ] && { rm -f $LOCKFILE; success; } || failure
     echo

--- a/kafka.init
+++ b/kafka.init
@@ -117,7 +117,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $PROG: "
-    killproc -p $PIDFILE $PROG
+    killproc -p $PIDFILE -d 60 $PROG
     RETVAL=$?
     [ $RETVAL -eq 0 ] && { rm -f $LOCKFILE; success; } || failure
     echo


### PR DESCRIPTION
killproc: A bigger delay because the default delay is 3 seconds on CentOS